### PR TITLE
Remove auth handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	go spdyConn.Serve(spdystream.NoOpStreamHandler, spdystream.RejectAuthHandler)
+	go spdyConn.Serve(spdystream.NoOpStreamHandler)
 	stream := spdyConn.CreateStream(http.Header{}, nil)
 	err = stream.Open(false)
 	if err != nil {
@@ -66,7 +66,7 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
-		go spdyConn.Serve(spdystream.MirrorStreamHandler, spdystream.NoAuthHandler)
+		go spdyConn.Serve(spdystream.MirrorStreamHandler)
 	}
 }
 ~~~~

--- a/handlers.go
+++ b/handlers.go
@@ -36,13 +36,3 @@ func MirrorStreamHandler(stream *Stream) {
 func NoOpStreamHandler(stream *Stream) {
 	stream.SendReply(http.Header{}, false)
 }
-
-// NoAuthHandler skips authentication.
-func NoAuthHandler(header http.Header, slot uint8, parent uint32) bool {
-	return true
-}
-
-// RejectAuthHandler rejects all remotely initiated connections.
-func RejectAuthHandler(header http.Header, slot uint8, parent uint32) bool {
-	return false
-}


### PR DESCRIPTION
Remove auth handler in favor of handling auth in stream handler.  Having a separate auth handler is no longer necessary since replies can be sent on the stream object and have no need to be sent directly by the stream frame handler.  This also allows greater flexibility in how rejected auth is handled, whether through a stream reset or sending an http status code in the reply frame.
