### PR TITLE
Remove stream open function

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -408,10 +408,10 @@ func (s *Connection) handlePingFrame(frame *spdy.PingFrame) error {
 // the reply frame.  If waiting for the reply is desired, use
 // the stream Wait or WaitTimeout function on the stream returned
 // by this function.
-func (s *Connection) CreateStream(headers http.Header, parent *Stream) *Stream {
+func (s *Connection) CreateStream(headers http.Header, parent *Stream, fin bool) (*Stream, error) {
 	streamId := s.getNextStreamId()
 	if streamId == 0 {
-		return nil
+		return nil, fmt.Errorf("Unable to get new stream id")
 	}
 
 	stream := &Stream{
@@ -429,7 +429,7 @@ func (s *Connection) CreateStream(headers http.Header, parent *Stream) *Stream {
 	s.streams[streamId] = stream
 	s.streamLock.Unlock()
 
-	return stream
+	return stream, s.sendStream(stream, fin)
 }
 
 // Closes spdy connection, including network connection used

--- a/spdy_test.go
+++ b/spdy_test.go
@@ -30,8 +30,7 @@ func TestSpdyStreams(t *testing.T) {
 	go spdyConn.Serve(NoOpStreamHandler, RejectAuthHandler)
 
 	authenticated = true
-	stream := spdyConn.CreateStream(http.Header{}, nil)
-	streamErr := stream.Open(false)
+	stream, streamErr := spdyConn.CreateStream(http.Header{}, nil, false)
 	if streamErr != nil {
 		t.Fatalf("Error creating stream: %s", streamErr)
 	}
@@ -122,8 +121,7 @@ func TestSpdyStreams(t *testing.T) {
 	}
 
 	authenticated = false
-	badStream := spdyConn.CreateStream(http.Header{}, nil)
-	badStreamErr := badStream.Open(false)
+	badStream, badStreamErr := spdyConn.CreateStream(http.Header{}, nil, false)
 	if badStreamErr != nil {
 		t.Fatalf("Error creating stream: %s", badStreamErr)
 	}

--- a/stream.go
+++ b/stream.go
@@ -129,19 +129,8 @@ func (s *Stream) Close() error {
 }
 
 // CreateSubStream creates a stream using the current as the parent
-func (s *Stream) CreateSubStream(headers http.Header) *Stream {
-	return s.conn.CreateStream(headers, s)
-}
-
-// Opens sends the stream frame, does not wait for reply frame.
-// Calling multiple times will result in a protocol error
-func (s *Stream) Open(fin bool) error {
-	if s == nil {
-		return fmt.Errorf("Attempt to open nil stream")
-	}
-
-	return s.conn.sendStream(s, fin)
-
+func (s *Stream) CreateSubStream(headers http.Header, fin bool) (*Stream, error) {
+	return s.conn.CreateStream(headers, s, fin)
 }
 
 // SetPriority sets the stream priority, does not affect the


### PR DESCRIPTION
Remove the stream open function to restore original stream open interface.  Interface was originally changed to protect against a race condition that was better handled through the stream lock.
