### PR TITLE
Make stream implement net.Conn

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -4,6 +4,7 @@ import (
 	"code.google.com/p/go.net/spdy"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"sync"
 	"time"
@@ -239,4 +240,28 @@ func (s *Stream) String() string {
 // sending data
 func (s *Stream) IsFinished() bool {
 	return s.finished
+}
+
+// Implement net.Conn interface
+
+func (s *Stream) LocalAddr() net.Addr {
+	return s.conn.conn.LocalAddr()
+}
+
+func (s *Stream) RemoteAddr() net.Addr {
+	return s.conn.conn.RemoteAddr()
+}
+
+// TODO set per stream values instead of connection-wide
+
+func (s *Stream) SetDeadline(t time.Time) error {
+	return s.conn.conn.SetDeadline(t)
+}
+
+func (s *Stream) SetReadDeadline(t time.Time) error {
+	return s.conn.conn.SetReadDeadline(t)
+}
+
+func (s *Stream) SetWriteDeadline(t time.Time) error {
+	return s.conn.conn.SetWriteDeadline(t)
 }


### PR DESCRIPTION
Added functions necessary for stream to implement net.Conn.  The implementation of these functions are not finalized and the current implementation is not necessarily ideal.  Ideally these functions would act on per stream, not updating the net.Conn used to create the spdy connection.  Initially this will be used to allow implementing interfaces based on net.Conn which use this library.
