### PR TITLE
Update README as stream.Open() function was removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ func main() {
 		panic(err)
 	}
 	go spdyConn.Serve(spdystream.NoOpStreamHandler)
-	stream := spdyConn.CreateStream(http.Header{}, nil)
-	err = stream.Open(false)
+	stream, err := spdyConn.CreateStream(http.Header{}, nil, false)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
To fix the client example as s.sendStream() was merged to CreateStream()
