### PR TITLE
Add more robust debug mode with server

### DIFF
--- a/contrib/debugserver/main.go
+++ b/contrib/debugserver/main.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"encoding/gob"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"code.google.com/p/go.net/spdy"
+	"github.com/docker/spdystream"
+)
+
+func init() {
+	spdystream.InitializeDebugServer()
+}
+
+func main() {
+	l, err := net.Listen("tcp", "localhost:9399")
+	if err != nil {
+		log.Fatalf("Error opening listener: %s", err)
+	}
+
+	for {
+		c, err := l.Accept()
+		if err != nil {
+			log.Fatalf("Accept error: %s")
+		}
+		go SpawnDebugHandler(c)
+	}
+
+}
+
+func SpawnDebugHandler(c net.Conn) {
+	defer c.Close()
+	decoder := gob.NewDecoder(c)
+	for {
+		var d spdystream.DebugFrame
+		if err := decoder.Decode(&d); err == io.EOF {
+			return
+		} else if err != nil {
+			panic(err)
+		}
+		if d.Frame == nil {
+			continue
+		}
+		handleFrame(&d)
+	}
+}
+
+func formatHeaders(h http.Header) string {
+	var headers []string
+	for k, v := range h {
+		if len(v) == 1 {
+			headers = append(headers, fmt.Sprintf("%s=%q", k, v[0]))
+		} else {
+			headers = append(headers, fmt.Sprintf("%s=%#v", k, v))
+		}
+	}
+	return strings.Join(headers, " ")
+}
+
+func formatData(d []byte) string {
+	if len(d) < 20 {
+		return fmt.Sprintf("%x", d)
+	} else {
+		return fmt.Sprintf("%x..", d[:19])
+	}
+}
+
+func isFin(h spdy.ControlFrameHeader) bool {
+	return h.Flags&spdy.ControlFlagFin == 1
+}
+
+func handleFrame(f *spdystream.DebugFrame) {
+	switch v := f.Frame.(type) {
+	case *spdy.SynStreamFrame:
+		formatLine(f, "stream", Green, fmt.Sprintf("%s", formatHeaders(v.Headers)), isFin(v.CFHeader), v.StreamId, f.T)
+	case *spdy.SynReplyFrame:
+		formatLine(f, "reply", Green, fmt.Sprintf("%s", formatHeaders(v.Headers)), isFin(v.CFHeader), v.StreamId, f.T)
+	case *spdy.DataFrame:
+		formatLine(f, "data", Cyan, fmt.Sprintf("(len: %d) %s", len(v.Data), formatData(v.Data)), v.Flags&spdy.DataFlagFin == 1, v.StreamId, f.T)
+	case *spdy.PingFrame:
+		formatLine(f, "ping", Magenta, fmt.Sprintf("(id: %d)", v.Id), isFin(v.CFHeader), 0, f.T)
+	case *spdy.GoAwayFrame:
+		formatLine(f, "goaway", Red, fmt.Sprintf("(last: %d, status: %d)", v.LastGoodStreamId, v.Status), isFin(v.CFHeader), 0, f.T)
+	case *spdy.RstStreamFrame:
+		formatLine(f, "reset", Red, fmt.Sprintf("(status: %d)", v.Status), isFin(v.CFHeader), v.StreamId, f.T)
+	case *spdy.HeadersFrame:
+		formatLine(f, "header", Cyan, formatHeaders(v.Headers), isFin(v.CFHeader), v.StreamId, f.T)
+	case *spdy.SettingsFrame:
+		formatLine(f, "settng", Yellow, "", isFin(v.CFHeader), 0, f.T)
+	case *spdy.WindowUpdateFrame:
+		formatLine(f, "window", Yellow, fmt.Sprintf("delta: %d bytes", v.DeltaWindowSize), isFin(v.CFHeader), v.StreamId, f.T)
+	default:
+		panic("Unsupported type")
+	}
+}
+
+func filterLocalhost(name string) string {
+	if strings.HasPrefix(name, "127.0.0.1:") {
+		return name[9:]
+	}
+	if strings.HasPrefix(name, "localhost:") {
+		return name[9:]
+	}
+	return name
+}
+
+func getName(f *spdystream.DebugFrame) string {
+	d := "<-"
+	if f.Send {
+		d = "->"
+	}
+	return fmt.Sprintf("%s%s%s", filterLocalhost(f.Local), d, filterLocalhost(f.Remote))
+}
+
+func formatLine(f *spdystream.DebugFrame, frameType, color, content string, fin bool, id spdy.StreamId, t time.Time) {
+	eof := ""
+	if fin {
+		eof = "fin"
+	}
+	fmt.Printf("%s%s %5d  %-6s %3s %s%s\n", color, getName(f), id, frameType, eof, content, Clear)
+
+}
+
+const Black = "\x1b[30;1m"
+const Red = "\x1b[31;1m"
+const Green = "\x1b[32;1m"
+const Yellow = "\x1b[33;1m"
+const Blue = "\x1b[34;1m"
+const Magenta = "\x1b[35;1m"
+const Cyan = "\x1b[36;1m"
+const White = "\x1b[37;1m"
+const Clear = "\x1b[0m"

--- a/stream.go
+++ b/stream.go
@@ -1,7 +1,6 @@
 package spdystream
 
 import (
-	"code.google.com/p/go.net/spdy"
 	"errors"
 	"fmt"
 	"io"
@@ -9,6 +8,8 @@ import (
 	"net/http"
 	"sync"
 	"time"
+
+	"code.google.com/p/go.net/spdy"
 )
 
 var (
@@ -60,6 +61,7 @@ func (s *Stream) WriteData(data []byte, fin bool) error {
 	s.conn.writeLock.Lock()
 	defer s.conn.writeLock.Unlock()
 	debugMessage("(%p) (%d) Writing data frame", s, s.streamId)
+	debugFrame(s.conn, dataFrame, true)
 	return s.conn.framer.WriteFrame(dataFrame)
 }
 
@@ -191,6 +193,7 @@ func (s *Stream) Reset() error {
 	}
 	s.conn.writeLock.Lock()
 	defer s.conn.writeLock.Unlock()
+	debugFrame(s.conn, resetFrame, true)
 	return s.conn.framer.WriteFrame(resetFrame)
 }
 

--- a/utils.go
+++ b/utils.go
@@ -1,16 +1,82 @@
 package spdystream
 
 import (
+	"encoding/gob"
 	"log"
+	"net"
 	"os"
+	"time"
+
+	"code.google.com/p/go.net/spdy"
 )
 
 var (
-	DEBUG = os.Getenv("DEBUG")
+	DEBUG     = os.Getenv("DEBUG")
+	debugChan chan *DebugFrame
 )
+
+type DebugFrame struct {
+	Local  string
+	Remote string
+	T      time.Time
+	Frame  spdy.Frame
+	Send   bool
+}
+
+func registerGob() {
+	gob.Register(&DebugFrame{})
+	gob.Register(&spdy.SynStreamFrame{})
+	gob.Register(&spdy.SynReplyFrame{})
+	gob.Register(&spdy.DataFrame{})
+	gob.Register(&spdy.HeadersFrame{})
+	gob.Register(&spdy.GoAwayFrame{})
+	gob.Register(&spdy.RstStreamFrame{})
+	gob.Register(&spdy.PingFrame{})
+	gob.Register(&spdy.SettingsFrame{})
+	gob.Register(&spdy.WindowUpdateFrame{})
+}
+
+func InitializeDebugServer() {
+	registerGob()
+}
+
+func init() {
+	if debugServer := os.Getenv("SPDYSTREAM_DEBUG"); debugServer != "" {
+		registerGob()
+		c := make(chan *DebugFrame)
+		w, err := net.Dial("tcp", debugServer)
+		if err != nil {
+			log.Printf("Cannot connect to debug server at %s", debugServer)
+		} else {
+			debugChan = c
+			go func() {
+				encoder := gob.NewEncoder(w)
+				for {
+					if err := encoder.Encode(<-c); err != nil {
+						log.Printf("Error sending debug frame: %s", err)
+						break
+					}
+				}
+			}()
+		}
+	}
+
+}
 
 func debugMessage(fmt string, args ...interface{}) {
 	if DEBUG != "" {
 		log.Printf(fmt, args...)
+	}
+}
+
+func debugFrame(c *Connection, f spdy.Frame, send bool) {
+	if debugChan != nil {
+		debugChan <- &DebugFrame{
+			Local:  c.conn.LocalAddr().String(),
+			Remote: c.conn.RemoteAddr().String(),
+			T:      time.Now().UTC(),
+			Frame:  f,
+			Send:   send,
+		}
 	}
 }


### PR DESCRIPTION
The debug server is still a work in progress but it has immediate benefits for debugging.

Usage:

Run Server

```
go run contrib/debugserver/main.go
```

Run tests

```
SPDYSTREAM_DEBUG=localhost:9399 go test -v .
```
