### PR TITLE
Calling Reset with data remaining to be read hangs

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -262,16 +262,17 @@ func (s *Connection) addStreamFrame(frame *spdy.SynStreamFrame) {
 	}
 
 	stream := &Stream{
-		streamId:   frame.StreamId,
-		parent:     parent,
-		conn:       s,
-		startChan:  make(chan error),
-		headers:    frame.Headers,
-		finished:   (frame.CFHeader.Flags & spdy.ControlFlagUnidirectional) != 0x00,
-		replyCond:  sync.NewCond(new(sync.Mutex)),
-		dataChan:   make(chan []byte),
-		headerChan: make(chan http.Header),
-		closeChan:  make(chan bool),
+		streamId:     frame.StreamId,
+		parent:       parent,
+		conn:         s,
+		startChan:    make(chan error),
+		headers:      frame.Headers,
+		finished:     (frame.CFHeader.Flags & spdy.ControlFlagUnidirectional) != 0x00,
+		replyCond:    sync.NewCond(new(sync.Mutex)),
+		dataChan:     make(chan []byte),
+		headerChan:   make(chan http.Header),
+		closeChan:    make(chan bool),
+		shutdownChan: make(chan struct{}),
 	}
 	if frame.CFHeader.Flags&spdy.ControlFlagFin != 0x00 {
 		close(stream.dataChan)
@@ -415,8 +416,12 @@ func (s *Connection) handleDataFrame(frame *spdy.DataFrame) error {
 			break
 		default:
 			debugMessage("(%p) (%d) Data frame send chan", stream, stream.streamId)
-			stream.dataChan <- frame.Data
-			debugMessage("(%p) (%d) Data frame sent", stream, stream.streamId)
+			select {
+			case stream.dataChan <- frame.Data:
+				debugMessage("(%p) (%d) Data frame sent", stream, stream.streamId)
+			case <-stream.shutdownChan:
+				debugMessage("(%p) (%d) Data frame not sent (stream shut down)", stream, stream.streamId)
+			}
 		}
 		stream.dataLock.RUnlock()
 	}
@@ -495,14 +500,15 @@ func (s *Connection) CreateStream(headers http.Header, parent *Stream, fin bool)
 	}
 
 	stream := &Stream{
-		streamId:   streamId,
-		parent:     parent,
-		conn:       s,
-		startChan:  make(chan error),
-		headers:    headers,
-		dataChan:   make(chan []byte),
-		headerChan: make(chan http.Header),
-		closeChan:  make(chan bool),
+		streamId:     streamId,
+		parent:       parent,
+		conn:         s,
+		startChan:    make(chan error),
+		headers:      headers,
+		dataChan:     make(chan []byte),
+		headerChan:   make(chan http.Header),
+		closeChan:    make(chan bool),
+		shutdownChan: make(chan struct{}),
 	}
 
 	debugMessage("(%p) (%p) Create stream", s, stream)

--- a/stream.go
+++ b/stream.go
@@ -33,6 +33,8 @@ type Stream struct {
 	replyCond  *sync.Cond
 	replied    bool
 	closeChan  chan bool
+
+	shutdownChan chan struct{} // closed when Reset is called (no more R/W).
 }
 
 // WriteData writes data to stream, sending a dataframe per call
@@ -166,6 +168,14 @@ func (s *Stream) Close() error {
 // Reset sends a reset frame, putting the stream into the fully closed state.
 func (s *Stream) Reset() error {
 	s.conn.removeStream(s)
+
+	// only close it once.
+	select {
+	case <-s.shutdownChan:
+		// already was closed.
+	default:
+		close(s.shutdownChan)
+	}
 
 	s.finishLock.Lock()
 	if s.finished {

--- a/stream_test.go
+++ b/stream_test.go
@@ -1,0 +1,106 @@
+package spdystream
+
+import (
+	"net"
+	"net/http"
+	"sync"
+	"testing"
+)
+
+func TestStreamReset(t *testing.T) {
+	var wg sync.WaitGroup
+	listen := "localhost:7743"
+	server, serverErr := runServer(listen, &wg)
+	if serverErr != nil {
+		t.Fatalf("Error initializing server: %s", serverErr)
+	}
+
+	conn, dialErr := net.Dial("tcp", listen)
+	if dialErr != nil {
+		t.Fatalf("Error dialing server: %s", dialErr)
+	}
+
+	spdyConn, spdyErr := NewConnection(conn, false)
+	if spdyErr != nil {
+		t.Fatalf("Error creating spdy connection: %s", spdyErr)
+	}
+	go spdyConn.Serve(NoOpStreamHandler)
+
+	authenticated = true
+	stream, streamErr := spdyConn.CreateStream(http.Header{}, nil, false)
+	if streamErr != nil {
+		t.Fatalf("Error creating stream: %s", streamErr)
+	}
+
+	buf := []byte("dskjahfkdusahfkdsahfkdsafdkas")
+	for i := 0; i < 10; i++ {
+		if _, err := stream.Write(buf); err != nil {
+			t.Fatalf("Error writing to stream: %s", err)
+		}
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := stream.Read(buf); err != nil {
+			t.Fatalf("Error reading from stream: %s", err)
+		}
+	}
+
+	// fmt.Printf("Resetting...\n")
+	if err := stream.Reset(); err != nil {
+		t.Fatalf("Error reseting stream: %s", err)
+	}
+
+	closeErr := server.Close()
+	if closeErr != nil {
+		t.Fatalf("Error shutting down server: %s", closeErr)
+	}
+	wg.Wait()
+}
+
+func TestStreamResetWithDataRemaining(t *testing.T) {
+	var wg sync.WaitGroup
+	listen := "localhost:7743"
+	server, serverErr := runServer(listen, &wg)
+	if serverErr != nil {
+		t.Fatalf("Error initializing server: %s", serverErr)
+	}
+
+	conn, dialErr := net.Dial("tcp", listen)
+	if dialErr != nil {
+		t.Fatalf("Error dialing server: %s", dialErr)
+	}
+
+	spdyConn, spdyErr := NewConnection(conn, false)
+	if spdyErr != nil {
+		t.Fatalf("Error creating spdy connection: %s", spdyErr)
+	}
+	go spdyConn.Serve(NoOpStreamHandler)
+
+	authenticated = true
+	stream, streamErr := spdyConn.CreateStream(http.Header{}, nil, false)
+	if streamErr != nil {
+		t.Fatalf("Error creating stream: %s", streamErr)
+	}
+
+	buf := []byte("dskjahfkdusahfkdsahfkdsafdkas")
+	for i := 0; i < 10; i++ {
+		if _, err := stream.Write(buf); err != nil {
+			t.Fatalf("Error writing to stream: %s", err)
+		}
+	}
+
+	// read a bit to make sure a goroutine gets to <-dataChan
+	if _, err := stream.Read(buf); err != nil {
+		t.Fatalf("Error reading from stream: %s", err)
+	}
+
+	// fmt.Printf("Resetting...\n")
+	if err := stream.Reset(); err != nil {
+		t.Fatalf("Error reseting stream: %s", err)
+	}
+
+	closeErr := server.Close()
+	if closeErr != nil {
+		t.Fatalf("Error shutting down server: %s", closeErr)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Not sure if you guys are still maintaining this pkg (libchan seems on hold/dead).

In any case, calling Reset with data remaining to be read hangs. This PR introduces a test that shows the issue, and a (pretty crappy) workaround. See commit msg:

```
This commit introduces a `shutdownChan` to Streams
that works around the bug described below. I opted
for this approach because `closeChan` is ambiguous
(i believe it means the remote side closed, but not
sure), and the logic of Stream's sync is hard
to follow/modify (i suggest moving to a world
where everything calls one of three close functions
closeOutgoing, closeIncoming, closeBoth).

Reset-with-data-remaining Bug: if a client calls
Reset() on a stream with data remaining to be read,
a goroutine's stuck in `stream.dataChan <- frame.Data`
and also holds `stream.dataLock`, which means caller
of Reset will hang forever on s.dataLock.Lock().
Try running "TestStreamResetWithDataRemaining" in
the previous commit. This commit fixes the deadlock.

Note: my inspection also revealed several race
conditions, in particular when reading many variables
which are protected by locks only sometimes. For
example: (s *Stream).IsFinished() does not lock
s.finishLock.
```