### PR TITLE
Expose Connection's closeChan for notifications

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -807,3 +807,7 @@ func (s *Connection) FindStream(streamId uint32) *Stream {
 	s.streamCond.L.Unlock()
 	return stream
 }
+
+func (s *Connection) CloseChan() <-chan bool {
+	return s.closeChan
+}


### PR DESCRIPTION
Expose Connection's closeChan to callers so they can be notified when
the connection is closed.

Signed-off-by: Andy Goldstein <agoldste@redhat.com>