### PR TITLE
Fix race in idle expiration

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -168,7 +168,10 @@ func (s *Stream) Close() error {
 // Reset sends a reset frame, putting the stream into the fully closed state.
 func (s *Stream) Reset() error {
 	s.conn.removeStream(s)
+	return s.resetStream()
+}
 
+func (s *Stream) resetStream() error {
 	s.finishLock.Lock()
 	if s.finished {
 		s.finishLock.Unlock()


### PR DESCRIPTION
On expiration reset is called, causing a race between resetting objects and accessing the streams. Additionally a deadlock occurs writing frames which can be avoided by running the actual sending of the resets in a goroutine.
