### PR TITLE
Remove close of datachan

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -322,6 +322,5 @@ func (s *Stream) closeRemoteChannels() {
 		close(s.closeChan)
 		s.dataLock.Lock()
 		defer s.dataLock.Unlock()
-		close(s.dataChan)
 	}
 }


### PR DESCRIPTION
Closing of the dataChan right after the closeChan can cause a race in select statements.
If select attemps the dataChan operation then a panic will happen.
Since dataChan is not used for synchronization, the closure of closeChan is enough to stop all data operations.

Fixes #60 

@ncdc 