### PR TITLE
close closeChan iff it is still open

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -320,8 +320,10 @@ func (s *Stream) closeRemoteChannels() {
 	s.closeLock.Lock()
 	defer s.closeLock.Unlock()
 	select {
-	case <-s.closeChan:
+	case _, ok := <-s.closeChan:
+		if ok {
+			close(s.closeChan)
+		}
 	default:
-		close(s.closeChan)
 	}
 }


### PR DESCRIPTION
Prevent sender from panicking when receiver process is unexpectedly killed. 

```
goroutine 73 [running]:
panic(0x4ca540, 0xc82016d5f0)
	/usr/local/go/src/runtime/panic.go:481 +0x3e6
github.com/docker/libchan.pSender.Close(0xc820759080, 0x0, 0x0)
	/Users/saahn/squared/go/elodina_kafka_client_work/src/github.com/docker/libchan/inmem.go:13 +0x2d
github.com/docker/libchan/spdy.(*stream).copySendChannel.func1(0xf85478, 0xc820759080, 0x1b60f00, 0xc82052efc0)
	/Users/saahn/squared/go/elodina_kafka_client_work/src/github.com/docker/libchan/spdy/encode.go:59 +0x53
created by github.com/docker/libchan/spdy.(*stream).copySendChannel
	/Users/saahn/squared/go/elodina_kafka_client_work/src/github.com/docker/libchan/spdy/encode.go:60 +0xd3
panic: close of closed channel
```